### PR TITLE
Improve typing for getValue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export const succeeded = (action: TrackedAction | IFunction) => {
   return (action as TrackedAction)?.success
 }
 
-function getValue<T, D extends T | undefined>(v: IGettable<Promise<T>> | Promise<T>, defaultValue?: D): T | D {
+function getValue<T, D extends T>(v: IGettable<Promise<T>> | Promise<T>, defaultValue?: D): T | D | undefined {
   const value = toPromise(v)
 
   return fromPromise(value).case({

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export const succeeded = (action: TrackedAction | IFunction) => {
   return (action as TrackedAction)?.success
 }
 
-function getValue<T, D extends T>(v: IGettable<Promise<T>> | Promise<T>, defaultValue?: D): T | D {
+function getValue<T, D extends T | undefined>(v: IGettable<Promise<T>> | Promise<T>, defaultValue?: D): T | D {
   const value = toPromise(v)
 
   return fromPromise(value).case({


### PR DESCRIPTION
The current version of getValue type always returns the unwrapped promise, but that is not true because if we don't provide a defaultParam, it'll be undefined until the promise resolves.

This fixes this issue, making this the new behavior (given `Promise<T>`):
* Using getValue without a defaultParam types it as `T | undefined`
* The defaultParam needs to have the same type of the value we are getting
* If we provide a defaultParam (as `D`) the type is `T | D`.